### PR TITLE
Send broadcast error

### DIFF
--- a/lib/pages/login/login.dart
+++ b/lib/pages/login/login.dart
@@ -138,7 +138,6 @@ class LoginController extends State<Login> with ControllerLoggy {
       return;
     }
 
-    loggy.info('Login');
     _signInSubscription = _signInInteractor
         .execute(
           email: email,

--- a/lib/pages/scanner/widgets/scanner_bar_code_label.dart
+++ b/lib/pages/scanner/widgets/scanner_bar_code_label.dart
@@ -51,6 +51,11 @@ class ScannerBarCodeLabel extends StatelessWidget with ViewLoggy {
         final qrTime = DateTime.fromMillisecondsSinceEpoch(qrData.timestamp);
 
         if (now.difference(qrTime).inSeconds > 60) {
+          controller.sendBroadcastErrorMessage(
+            ticketId: qrData.ticketId,
+            error: 'Ticket expired',
+          );
+
           return Text(
             'Ticket expired. Please go back and navigate to ticket details',
             overflow: TextOverflow.fade,


### PR DESCRIPTION
## Summary
This pull request includes several changes to improve error handling and logging in the `Scanner` feature of the application. The most important changes include adding a new method for broadcasting error messages via Supabase, modifying the error handling in the `ScannerController`, and updating the `ScannerBarCodeLabel` to use the new broadcast error method.

Error handling improvements:

* [`lib/pages/scanner/scanner.dart`](diffhunk://#diff-b9751dad5077a59ab9da97d89f042a6cd01a42098f5863fcef6fc351b9f6e3ecL176-R216): Added `sendBroadcastErrorMessage` method to broadcast error messages via Supabase and updated `_handleScanTicketFailure` to use this method for different failure scenarios.
* [`lib/pages/scanner/widgets/scanner_bar_code_label.dart`](diffhunk://#diff-4c1fd9c114f650f006b4c343d6307c10cb556cd5a61f03a5ac1d58faeb570d87R54-R58): Updated `ScannerBarCodeLabel` to call `sendBroadcastErrorMessage` when a ticket is expired.

Logging changes:

* [`lib/pages/login/login.dart`](diffhunk://#diff-516f0df80c47168df4683e203bf6a6d85bedd732152b4b9eb89d3af03475d9acL141): Removed an unnecessary log statement in the `LoginController`.

Dependency updates:

* [`lib/pages/scanner/scanner.dart`](diffhunk://#diff-b9751dad5077a59ab9da97d89f042a6cd01a42098f5863fcef6fc351b9f6e3ecR18): Added import for `supabase_flutter` to enable broadcasting error messages.