### PR TITLE
Bump version to v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.3 - 21/12/2024
+## Added
+- Send broadcast when scan ticket error
+
 ## v0.0.2 - 18/12/2024
 ### Added
 - Handle scan ticket's QR code

--- a/lib/pages/login/login.dart
+++ b/lib/pages/login/login.dart
@@ -138,7 +138,6 @@ class LoginController extends State<Login> with ControllerLoggy {
       return;
     }
 
-    loggy.info('Login');
     _signInSubscription = _signInInteractor
         .execute(
           email: email,

--- a/lib/pages/scanner/widgets/scanner_bar_code_label.dart
+++ b/lib/pages/scanner/widgets/scanner_bar_code_label.dart
@@ -51,6 +51,11 @@ class ScannerBarCodeLabel extends StatelessWidget with ViewLoggy {
         final qrTime = DateTime.fromMillisecondsSinceEpoch(qrData.timestamp);
 
         if (now.difference(qrTime).inSeconds > 60) {
+          controller.sendBroadcastErrorMessage(
+            ticketId: qrData.ticketId,
+            error: 'Ticket expired',
+          );
+
           return Text(
             'Ticket expired. Please go back and navigate to ticket details',
             overflow: TextOverflow.fade,


### PR DESCRIPTION
## Summary
This pull request includes changes to add error broadcasting functionality when a scan ticket error occurs and some minor code cleanups. The most important changes are:

### Error Broadcasting Enhancements:

* [`lib/pages/scanner/scanner.dart`](diffhunk://#diff-b9751dad5077a59ab9da97d89f042a6cd01a42098f5863fcef6fc351b9f6e3ecL176-R216): Added the `sendBroadcastErrorMessage` method to send broadcast messages on scan ticket errors and updated `_handleScanTicketFailure` to use this method.
* [`lib/pages/scanner/widgets/scanner_bar_code_label.dart`](diffhunk://#diff-4c1fd9c114f650f006b4c343d6307c10cb556cd5a61f03a5ac1d58faeb570d87R54-R58): Updated the `ScannerBarCodeLabel` class to send a broadcast error message when a ticket is expired.

### Code Cleanups:

* [`lib/pages/login/login.dart`](diffhunk://#diff-516f0df80c47168df4683e203bf6a6d85bedd732152b4b9eb89d3af03475d9acL141): Removed an unnecessary log statement from the `LoginController` class.
* [`lib/pages/scanner/scanner.dart`](diffhunk://#diff-b9751dad5077a59ab9da97d89f042a6cd01a42098f5863fcef6fc351b9f6e3ecR18): Added an import statement for `supabase_flutter` to support the new error broadcasting functionality.

### Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Updated the changelog to include the new error broadcasting feature.